### PR TITLE
chore(deploy): publish to testnet - 0xc42e20

### DIFF
--- a/Move.lock
+++ b/Move.lock
@@ -2,25 +2,55 @@
 
 [move]
 version = 3
-manifest_digest = "201E12D5DD2D922504EABF60E7D6E9D63B18350929C1B892CA14BC1A55381555"
-deps_digest = "F8BBB0CCB2491CA29A3DF03D6F92277A4F3574266507ACD77214D37ECA3F3082"
+manifest_digest = "7910AB97394131E7C37C9CDC7C5DC095E28BF7F17746EF1D0B0C87A0203BA1F3"
+deps_digest = "F9B494B64F0615AED0E98FC12A85B85ECD2BC5185C22D30E7F67786BB52E507C"
 dependencies = [
+  { id = "Bridge", name = "Bridge" },
+  { id = "MoveStdlib", name = "MoveStdlib" },
   { id = "Sui", name = "Sui" },
+  { id = "SuiSystem", name = "SuiSystem" },
+]
+
+[[move.package]]
+id = "Bridge"
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "c1f1ae650fb9f9248b39a569400b4420820868db", subdir = "crates/sui-framework/packages/bridge" }
+
+dependencies = [
+  { id = "MoveStdlib", name = "MoveStdlib" },
+  { id = "Sui", name = "Sui" },
+  { id = "SuiSystem", name = "SuiSystem" },
 ]
 
 [[move.package]]
 id = "MoveStdlib"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "framework/testnet", subdir = "crates/sui-framework/packages/move-stdlib" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "c1f1ae650fb9f9248b39a569400b4420820868db", subdir = "crates/sui-framework/packages/move-stdlib" }
 
 [[move.package]]
 id = "Sui"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "framework/testnet", subdir = "crates/sui-framework/packages/sui-framework" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "c1f1ae650fb9f9248b39a569400b4420820868db", subdir = "crates/sui-framework/packages/sui-framework" }
 
 dependencies = [
   { id = "MoveStdlib", name = "MoveStdlib" },
+]
+
+[[move.package]]
+id = "SuiSystem"
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "c1f1ae650fb9f9248b39a569400b4420820868db", subdir = "crates/sui-framework/packages/sui-system" }
+
+dependencies = [
+  { id = "MoveStdlib", name = "MoveStdlib" },
+  { id = "Sui", name = "Sui" },
 ]
 
 [move.toolchain-version]
 compiler-version = "1.61.2"
 edition = "2024.beta"
 flavor = "sui"
+
+[env]
+
+[env.testnet]
+chain-id = "4c78adac"
+original-published-id = "0xc42e20749aeb3df5a5fc3af0fc008ab7b17a7537aefda9291a8ed725ee95c024"
+latest-published-id = "0xc42e20749aeb3df5a5fc3af0fc008ab7b17a7537aefda9291a8ed725ee95c024"
+published-version = "1"

--- a/Move.toml
+++ b/Move.toml
@@ -1,6 +1,7 @@
 [package]
 name = "SuiMoveAdmin"
 edition = "2024.beta"
+published-at = "0xc42e20749aeb3df5a5fc3af0fc008ab7b17a7537aefda9291a8ed725ee95c024"
 
 [addresses]
-sui_move_admin = "0x0"
+sui_move_admin = "0xc42e20749aeb3df5a5fc3af0fc008ab7b17a7537aefda9291a8ed725ee95c024"

--- a/README.md
+++ b/README.md
@@ -12,6 +12,14 @@
 
 ---
 
+## Deployment
+
+| Network | PackageID | UpgradeCap | Version | Date |
+|---------|-----------|------------|---------|------|
+| testnet | `0xc42e20749aeb3df5a5fc3af0fc008ab7b17a7537aefda9291a8ed725ee95c024` | `0x1de91b08f8b91e05f334d903c5649005b59430a88ee557edb4ed711397467ca4` | 1 | 2025-12-07 |
+
+---
+
 ```toml
 # Move.toml
 [dependencies]


### PR DESCRIPTION
## Deployment Summary

| Field | Value |
|-------|-------|
| Network | testnet |
| PackageID | `0xc42e20749aeb3df5a5fc3af0fc008ab7b17a7537aefda9291a8ed725ee95c024` |
| UpgradeCap | `0x1de91b08f8b91e05f334d903c5649005b59430a88ee557edb4ed711397467ca4` |
| Operation | deploy |
| TxDigest | `8dynW4N2vdVJkUSFAfNY4DXg5wjuTwyQFkzRCgk9YQq9` |
| Version | 1 |

### Changes
- Updated Move.toml with published-at
- Updated README deployment table
- Move.lock updated

### Explorer Link
https://testnet.suivision.xyz/package/0xc42e20749aeb3df5a5fc3af0fc008ab7b17a7537aefda9291a8ed725ee95c024

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>