### PR TITLE
docs(readme): add testnet deployment information

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,15 @@ public fun admin_only(cap: &AdminCap<MY_MODULE>, ctx: &TxContext) {
 
 ---
 
+## Testnet
+
+| Type | ID | Version | Date |
+|---------|-----------|------------|---------|
+| PackageID | `0xc42e20749aeb3df5a5fc3af0fc008ab7b17a7537aefda9291a8ed725ee95c024`  | 1 | 07/12/2025 |
+| UpgradeCap | `0x1de91b08f8b91e05f334d903c5649005b59430a88ee557edb4ed711397467ca4` | 1 | 07/12/2025 |
+
+---
+
 ## API
 
 ### Create Super Admins


### PR DESCRIPTION
## Summary
Adds the testnet deployment information to the README.md as requested in issue #7.

## Changes
- Added new "Testnet" section to README.md with deployment IDs table
- Table includes PackageID, UpgradeCap, Version, and Date
- Placed after Features section, before API section

## Deployment IDs Added
| Type | ID | Version | Date |
|---------|-----------|------------|---------|
| PackageID | `0xc42e20749aeb3df5a5fc3af0fc008ab7b17a7537aefda9291a8ed725ee95c024` | 1 | 07/12/2025 |
| UpgradeCap | `0x1de91b08f8b91e05f334d903c5649005b59430a88ee557edb4ed711397467ca4` | 1 | 07/12/2025 |

## Linked Issue
Closes #7

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)