### PR TITLE
docs(readme): consolidate testnet deployment info to match requested format

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,12 @@
 
 ---
 
-## Deployment
+## Testnet
 
-| Network | PackageID | UpgradeCap | Version | Date |
-|---------|-----------|------------|---------|------|
-| testnet | `0xc42e20749aeb3df5a5fc3af0fc008ab7b17a7537aefda9291a8ed725ee95c024` | `0x1de91b08f8b91e05f334d903c5649005b59430a88ee557edb4ed711397467ca4` | 1 | 2025-12-07 |
+| Type | ID | Version | Date |
+|---------|-----------|------------|---------|
+| PackageID | `0xc42e20749aeb3df5a5fc3af0fc008ab7b17a7537aefda9291a8ed725ee95c024`  | 1 | 07/12/2025 |
+| UpgradeCap | `0x1de91b08f8b91e05f334d903c5649005b59430a88ee557edb4ed711397467ca4` | 1 | 07/12/2025 |
 
 ---
 
@@ -50,15 +51,6 @@ public fun admin_only(cap: &AdminCap<MY_MODULE>, ctx: &TxContext) {
 - **Epoch-based expiration** — Temp admins auto-expire
 - **No `store` ability** — Caps can't be transferred by arbitrary contracts
 - **Import, don't deploy** — One audited module for the ecosystem
-
----
-
-## Testnet
-
-| Type | ID | Version | Date |
-|---------|-----------|------------|---------|
-| PackageID | `0xc42e20749aeb3df5a5fc3af0fc008ab7b17a7537aefda9291a8ed725ee95c024`  | 1 | 07/12/2025 |
-| UpgradeCap | `0x1de91b08f8b91e05f334d903c5649005b59430a88ee557edb4ed711397467ca4` | 1 | 07/12/2025 |
 
 ---
 


### PR DESCRIPTION
## Summary

Fixes #7

Updates the README to use a single, consolidated testnet deployment table with the requested format.

## Changes Made

- Replaced the 'Deployment' section with the 'Testnet' section using the requested table format:
  ```
  | Type | ID | Version | Date |
  ```
- Removed duplicate testnet information (there were two sections with the same data)
- Each ID now has its own row (PackageID and UpgradeCap on separate lines)

## Before

Two separate sections with different formats:
1. 'Deployment' section with Network/PackageID/UpgradeCap columns (all on one row)
2. 'Testnet' section with Type/ID/Version/Date columns (IDs on separate rows)

## After

Single 'Testnet' section at the top with the requested format:
| Type | ID | Version | Date |
|---------|-----------|------------|---------|
| PackageID | `0xc42...` | 1 | 07/12/2025 |
| UpgradeCap | `0x1de...` | 1 | 07/12/2025 |